### PR TITLE
Add codemods to use deprecated Borderbox + Dropdown

### DIFF
--- a/src/use-deprecated-borderbox.js
+++ b/src/use-deprecated-borderbox.js
@@ -1,0 +1,24 @@
+const { SyntaxKind } = require('ts-morph');
+const updateImportDeclaration = require('./utils/change-import-to-deprecated');
+
+const componentImportNames = ['BorderBox', 'BorderBoxProps'];
+const fileName = 'BorderBox';
+
+const transform = (project) => {
+  const sourceFiles = project.getSourceFiles();
+
+  sourceFiles.forEach((sourceFile) => {
+    try {
+      sourceFile.getDescendantsOfKind(SyntaxKind.ImportDeclaration).forEach((declaration) => {
+        declaration = updateImportDeclaration(declaration, sourceFile, componentImportNames, fileName);
+      });
+
+      // save source back to file
+      sourceFile.saveSync();
+    } catch (error) {
+      console.log(error);
+    }
+  });
+};
+
+module.exports = transform;

--- a/src/use-deprecated-dropdown.js
+++ b/src/use-deprecated-dropdown.js
@@ -1,0 +1,38 @@
+const { SyntaxKind } = require('ts-morph');
+const updateImportDeclaration = require('./utils/change-import-to-deprecated');
+
+const componentImportNames = [
+  'Dropdown',
+  'DropdownProps',
+  'DropdownMenuProps',
+  'DropdownItemProps',
+  'DropdownButtonProps',
+  'DropdownCaretProps'
+];
+const fileName = 'Dropdown';
+const fileNameToIgnore = 'DropdownMenu'; // not the same component
+
+const transform = (project) => {
+  const sourceFiles = project.getSourceFiles();
+
+  sourceFiles.forEach((sourceFile) => {
+    try {
+      sourceFile.getDescendantsOfKind(SyntaxKind.ImportDeclaration).forEach((declaration) => {
+        declaration = updateImportDeclaration(
+          declaration,
+          sourceFile,
+          componentImportNames,
+          fileName,
+          fileNameToIgnore
+        );
+      });
+
+      // save source back to file
+      sourceFile.saveSync();
+    } catch (error) {
+      console.log(error);
+    }
+  });
+};
+
+module.exports = transform;

--- a/tests/use-deprecated-borderbox.test.js
+++ b/tests/use-deprecated-borderbox.test.js
@@ -1,0 +1,51 @@
+const createProject = require('../src/utils/create-project');
+const transform = require('../src/use-deprecated-borderbox');
+
+// setup a project
+const project = createProject();
+
+const createFixture = (code) => {
+  project.createSourceFile('tmp/fixture.js', code, { overwrite: true });
+};
+const getResult = () => {
+  const sourceFile = project.getSourceFile('tmp/fixture.js');
+  return sourceFile.getFullText();
+};
+
+test('change import specifier to @primer/react/deprecated', () => {
+  createFixture(`import { BorderBox } from '@primer/react';`);
+  transform(project);
+  expect(getResult()).toBe(`import { BorderBox } from '@primer/react/deprecated';`);
+});
+
+test('skip import declaration that does not have BorderBox', () => {
+  createFixture(`import { ThemeProvider } from '@primer/react';`);
+  transform(project);
+  expect(getResult()).toBe(`import { ThemeProvider } from '@primer/react';`);
+});
+
+test('change import specifier with multiple imports', () => {
+  createFixture(`import { BorderBox, BorderBoxProps } from '@primer/react';`);
+  transform(project);
+  expect(getResult()).toBe(`import { BorderBox, BorderBoxProps } from '@primer/react/deprecated';`);
+});
+
+test('change import specifier when specifier is lib-esm', () => {
+  createFixture(`import { BorderBox } from '@primer/react/lib-esm/BorderBox';`);
+  transform(project);
+  expect(getResult()).toBe(`import { BorderBox } from '@primer/react/lib-esm/deprecated/BorderBox';`);
+});
+
+test('change import specifier when specifier is lib', () => {
+  createFixture(`import { BorderBox } from '@primer/react/lib/BorderBox';`);
+  transform(project);
+  expect(getResult()).toBe(`import { BorderBox } from '@primer/react/lib/deprecated/BorderBox';`);
+});
+
+test('split + change import declaration when multiple components are imported', () => {
+  createFixture(`import { BorderBox, TextInput } from '@primer/react';`);
+  transform(project);
+  expect(getResult()).toBe(
+    `import { TextInput } from '@primer/react';\nimport { BorderBox } from '@primer/react/deprecated';\n`
+  );
+});

--- a/tests/use-deprecated-dropdown.test.js
+++ b/tests/use-deprecated-dropdown.test.js
@@ -1,0 +1,63 @@
+const createProject = require('../src/utils/create-project');
+const transform = require('../src/use-deprecated-dropdown');
+
+// setup a project
+const project = createProject();
+
+const createFixture = (code) => {
+  project.createSourceFile('tmp/fixture.js', code, { overwrite: true });
+};
+const getResult = () => {
+  const sourceFile = project.getSourceFile('tmp/fixture.js');
+  return sourceFile.getFullText();
+};
+
+test('change import specifier to @primer/react/deprecated', () => {
+  createFixture(`import { Dropdown } from '@primer/react';`);
+  transform(project);
+  expect(getResult()).toBe(`import { Dropdown } from '@primer/react/deprecated';`);
+});
+
+test('skip import declaration that does not have Dropdown', () => {
+  createFixture(`import { ThemeProvider } from '@primer/react';`);
+  transform(project);
+  expect(getResult()).toBe(`import { ThemeProvider } from '@primer/react';`);
+});
+
+test('change import specifier with multiple imports', () => {
+  createFixture(`import { Dropdown, DropdownProps } from '@primer/react';`);
+  transform(project);
+  expect(getResult()).toBe(`import { Dropdown, DropdownProps } from '@primer/react/deprecated';`);
+});
+
+test('change import specifier when specifier is lib-esm', () => {
+  createFixture(`import { Dropdown } from '@primer/react/lib-esm/Dropdown';`);
+  transform(project);
+  expect(getResult()).toBe(`import { Dropdown } from '@primer/react/lib-esm/deprecated/Dropdown';`);
+});
+
+test('change import specifier when specifier is lib', () => {
+  createFixture(`import { Dropdown } from '@primer/react/lib/Dropdown';`);
+  transform(project);
+  expect(getResult()).toBe(`import { Dropdown } from '@primer/react/lib/deprecated/Dropdown';`);
+});
+
+test('split + change import declaration when multiple components are imported', () => {
+  createFixture(`import { Dropdown, TextInput } from '@primer/react';`);
+  transform(project);
+  expect(getResult()).toBe(
+    `import { TextInput } from '@primer/react';\nimport { Dropdown } from '@primer/react/deprecated';\n`
+  );
+});
+
+test("skip DropdownMenu, that's a different component", () => {
+  createFixture(`
+    import { DropdownMenu } from '@primer/react';
+    import { DropdownMenu } from '@primer/react/lib/DropdownMenu';
+  `);
+  transform(project);
+  expect(getResult()).toBe(`
+    import { DropdownMenu } from '@primer/react';
+    import { DropdownMenu } from '@primer/react/lib/DropdownMenu';
+  `);
+});


### PR DESCRIPTION
```diff
- import {BorderBox, Dropdown} from '@primer/react'
+ import {BorderBox, Dropdown} from '@primer/react/deprecated'
```